### PR TITLE
DSE-511 builds unauthenticated HAT proxy for applications

### DIFF
--- a/hat/app/org/hatdex/hat/api/controllers/Applications.scala
+++ b/hat/app/org/hatdex/hat/api/controllers/Applications.scala
@@ -58,6 +58,25 @@ class Applications @Inject() (
 
   val logger: Logger = Logger(this.getClass)
 
+  def hmi(id: String): Action[AnyContent] =
+    UnsecuredAction.async { _ =>
+      applicationsService
+        .hmiDetails(id)
+        .map(
+          _.map(app => Ok(Json.toJson(app)))
+            .getOrElse(
+              NotFound(
+                Json.toJson(
+                  ErrorMessage(
+                    "Not Found",
+                    s"Application configuration for ID $id could not be found. Make sure application is correctly registered"
+                  )
+                )
+              )
+            )
+        )
+    }
+
   def applications(): Action[AnyContent] =
     SecuredAction(
       ContainsApplicationRole(Owner(), ApplicationList()) || WithRole(Owner())

--- a/hat/app/org/hatdex/hat/api/service/applications/ApplicationsService.scala
+++ b/hat/app/org/hatdex/hat/api/service/applications/ApplicationsService.scala
@@ -132,6 +132,10 @@ class ApplicationsService @Inject() (
     wsClient
   )
 
+  def hmiDetails(id: String): Future[Option[Application]] = {
+    trustedApplicationProvider.application(id) // calls cached by TrustedApplicationProvider
+  }
+
   def applicationStatus(
       id: String,
       bustCache: Boolean = false

--- a/hat/app/org/hatdex/hat/api/service/applications/TrustedApplicationProvider.scala
+++ b/hat/app/org/hatdex/hat/api/service/applications/TrustedApplicationProvider.scala
@@ -25,11 +25,11 @@
 package org.hatdex.hat.api.service.applications
 
 import javax.inject.Inject
-
 import org.hatdex.dex.apiV2.services.DexClient
+import org.hatdex.dex.apiV2.services.Errors.ApiException
 import org.hatdex.hat.api.models.applications.Application
 import org.hatdex.hat.api.service.RemoteExecutionContext
-import play.api.Configuration
+import play.api.{Configuration, Logger}
 import play.api.cache.AsyncCacheApi
 import play.api.libs.ws.WSClient
 
@@ -49,6 +49,8 @@ class TrustedApplicationProviderDex @Inject() (
     cache: AsyncCacheApi
   )(implicit val rec: RemoteExecutionContext)
     extends TrustedApplicationProvider {
+
+  private val logger = Logger(this.getClass)
 
   private val dexClient = new DexClient(
     wsClient,
@@ -72,6 +74,21 @@ class TrustedApplicationProviderDex @Inject() (
   }
 
   def application(id: String): Future[Option[Application]] = {
-    applications.map(_.find(_.id == id))
+    cache.getOrElseUpdate(
+      s"apps:dex:$id",
+      dexApplicationsCacheDuration
+    ) {
+      dexClient.application(id, None)
+    }.map(Some(_))
+      .recover {
+        case e: ApiException =>
+          logger.warn(s"Application config not found: ${e.getMessage}")
+          None
+
+        case e =>
+          logger.error(s"Unexpected failure while fetching application. ${e.getMessage}")
+          None
+      }
+
   }
 }

--- a/hat/conf/v26.routes
+++ b/hat/conf/v26.routes
@@ -51,6 +51,7 @@ GET           /migrate                                                          
 
 GET           /applications                                                                  org.hatdex.hat.api.controllers.Applications.applications()
 GET           /applications/hmi                                                              org.hatdex.hat.api.controllers.Applications.applications()
+GET           /applications/:application/hmi                                                 org.hatdex.hat.api.controllers.Applications.hmi(application)
 GET           /applications/:application                                                     org.hatdex.hat.api.controllers.Applications.applicationStatus(application)
 GET           /applications/:application/setup                                               org.hatdex.hat.api.controllers.Applications.applicationSetup(application)
 GET           /applications/:application/disable                                             org.hatdex.hat.api.controllers.Applications.applicationDisable(application)


### PR DESCRIPTION
The PR adds a new API endpoint for the frontend to be able to fetch application info without any user authentication:
`GET  /api/v2.6/applications/:application/hmi`

Implementation uses application detail caching for efficiency and thus will incur a delay on update propagation from the centralised Application Provider.