### PR TITLE
hotfixes config issue taking registry host from env

### DIFF
--- a/hat/conf/application.conf
+++ b/hat/conf/application.conf
@@ -340,6 +340,7 @@ she {
 
 hatters {
   address = "hatters.hubofallthings.com"
+  address = ${?PDA_REGISTRY_HOST}
   scheme = "https://"
 }
 


### PR DESCRIPTION
This is an urgent hotfix to configure PDA registry host through the environment variable. Without it, PDA claim process is broken.