### PR TITLE
Enables Weizmann score SHE function

### DIFF
--- a/hat/conf/application.conf
+++ b/hat/conf/application.conf
@@ -333,7 +333,7 @@ she {
        baseUrl = ${?DROPS_SHE_BASE_URL}
        namespace = "emitto"
        endpoint = "healthsurveyscores"
-       experimental = true
+       experimental = false
     }
   ]
 }


### PR DESCRIPTION
Currently, the only way to enable a SHE function in the live environment is via configuration update. This PR enables Weizmann score function in the production environment.