### PR TITLE
DSE-690 Adds Weizmann score function to the HAT configuration

### DIFF
--- a/hat/conf/she.conf
+++ b/hat/conf/she.conf
@@ -81,5 +81,14 @@ she {
       endpoint = "healthsurveyscores"
       experimental = true
     }
+    {
+      id = "weizmann-score"
+      version = "0.1.0"
+      baseUrl = "weizmann-score-dev"
+      baseUrl = ${?DROPS_SHE_BASE_URL}
+      namespace = "emitto"
+      endpoint = "healthsurveyscores"
+      experimental = false
+    }
   ]
 }


### PR DESCRIPTION
We somehow manage to loose the function configuration during config refactor and merging. Re-adding the configuration to fix the bug.