### PR TITLE
DAS-117 #comment Add more context.

### DIFF
--- a/hat/app/org/hatdex/hat/resourceManagement/HatServerProvider.scala
+++ b/hat/app/org/hatdex/hat/resourceManagement/HatServerProvider.scala
@@ -82,7 +82,7 @@ class HatServerProviderImpl @Inject() (
     configuration.get[FiniteDuration]("resourceManagement.serverIdleTimeout")
 
   def retrieve(hatAddress: String): Future[Option[HatServer]] = {
-    logger.warn(s"HatServiceProvider.retrieve: looking up hatAddress: server:${hatAddress}")
+    logger.info(s"HatServiceProvider.retrieve: looking up hatAddress: server:${hatAddress}")
 
     cache
       .get[HatServer](s"server:$hatAddress")
@@ -108,7 +108,7 @@ class HatServerProviderImpl @Inject() (
             } recoverWith {
               case e =>
                 logger.warn(
-                  s"Error while retrieving HAT $hatAddress info: ${e.getMessage}"
+                  s"Error while retrieving HAT $hatAddress info: ${e.getMessage} ${e.getStackTrace()}"
                 )
                 val error = new HatServerDiscoveryException(
                   "HAT Server info retrieval failed",

--- a/hat/app/org/hatdex/hat/resourceManagement/actors/HatServerProviderActor.scala
+++ b/hat/app/org/hatdex/hat/resourceManagement/actors/HatServerProviderActor.scala
@@ -37,6 +37,7 @@ import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
+import views.html.helper.select
 
 class HatServerProviderActor @Inject() (
     hatServerActorFactory: HatServerActor.Factory,
@@ -50,25 +51,25 @@ class HatServerProviderActor @Inject() (
   import HatServerProviderActor._
 
   private val activeServers = mutable.HashMap[String, ActorRef]()
-  private implicit val hatServerTimeout: Timeout =
+  implicit private val hatServerTimeout: Timeout =
     configuration.get[FiniteDuration](
       "resourceManagement.serverProvisioningTimeout"
     )
 
   def receive: Receive = {
     case HatServerRetrieve(hat) =>
-      log.debug(s"Retrieve HAT server $hat for $sender")
+      log.info(s"Retrieve HAT server $hat for $sender")
       val retrievingSender = sender
       getHatServerActor(hat) map { hatServerActor =>
-        log.debug(
-          s"Got HAT server provider actor, forwarding retrieval message with sender $sender $retrievingSender"
+        log.info(
+          s"Success: Got HAT server provider actor, forwarding retrieval message with sender $sender $retrievingSender"
         )
         hatServerActor tell (HatServerActor.HatRetrieve(), retrievingSender)
       } onComplete {
         case Success(_) => ()
         case Failure(e) =>
           log.warn(
-            s"Error while getting HAT server provider actor: ${e.getMessage}"
+            s"Failure: Error while getting HAT server provider actor: ${e.getMessage}"
           )
       }
 
@@ -79,42 +80,40 @@ class HatServerProviderActor @Inject() (
       activeHatcounter.decrease()
 
     case message =>
-      log.debug(s"Received unexpected message $message")
+      log.warn(s"Received unexpected message $message")
   }
 
-  private def getHatServerActor(hat: String): Future[ActorRef] = {
+  private def getHatServerActor(hat: String): Future[ActorRef] =
     doFindOrCreate(hat, hatServerTimeout.duration / 4)
-  }
 
   private val maxAttempts = 3
   private def doFindOrCreate(
       hat: String,
       timeout: FiniteDuration,
-      depth: Int = 0
-    ): Future[ActorRef] = {
+      depth: Int = 0): Future[ActorRef] = {
     if (depth >= maxAttempts) {
       log.error(s"HAT server actor for $hat not resolved")
       throw new RuntimeException(
         s"Can not create actor for $hat and reached max attempts of $maxAttempts"
       )
     }
-    val selection = s"/user/hatServerProviderActor/hat:$hat"
 
-    context.actorSelection(selection).resolveOne(timeout) map {
-      hatServerActor =>
-        log.debug(s"HAT server actor $selection resolved")
-        hatServerActor
+    val selection = s"/user/hatServerProviderActor/hat:$hat"
+    log.info(s"ActorSelection: ${selection}")
+
+    context.actorSelection(selection).resolveOne(timeout) map { hatServerActor =>
+      log.info(s"HAT server actor $selection resolved")
+      hatServerActor
     } recoverWith {
       case ActorNotFound(_) =>
-        log.debug(s"HAT server actor ($selection) not found, injecting child")
+        log.warn(s"HAT server actor ($selection) not found, injecting child")
         val hatServerActor = injectedChild(
           hatServerActorFactory(hat),
           s"hat:$hat",
-          props = (props: Props) =>
-            props.withDispatcher("hat-server-provider-actor-dispatcher")
+          props = (props: Props) => props.withDispatcher("hat-server-provider-actor-dispatcher")
         )
         activeServers(hat) = hatServerActor
-        log.debug(s"Injected actor $hatServerActor")
+        log.warn(s"Injected actor $hatServerActor")
         doFindOrCreate(hat, timeout, depth + 1)
     }
   }


### PR DESCRIPTION
## Description
While investigating the issue, it was difficult to get context due to a lack of logging, so this adds more around the code where the problem is.

## AC
Over the last 24h period we have identified at least 3 separate HAT login failures with the same log pattern. An example of the failure logs:

```
[WARN ] [01/12/2021 09:31:42] [o.h.h.r.a.HatServerProviderActor] Error while getting HAT server provider actor: actor name [hat:steveashby.hubofallthings.net] is not unique! 
[INFO ] [01/12/2021 09:31:42] [api] [77.103.220.124] [GET:steveashby.hubofallthings.net:/users/access_token] [401] [485:ms] [hats:1] [unauthenticated@_]
[WARN ] [01/12/2021 09:31:47] [o.h.h.r.HatServerProviderImpl] Error while retrieving HAT steveashby.hubofallthings.net info: Ask timed out on [Actor[akka://application/user/hatServerProviderActor#1759568681]] after [5000 ms]. Message of type [org.hatdex.hat.resourceManagement.actors.HatServerProviderActor$HatServerRetrieve]. A typical reason for `AskTimeoutException` is that the recipient actor didn't send a reply.
[INFO ] [01/12/2021 09:31:47] [api] [77.103.220.124] [GET:steveashby.hubofallthings.net:/users/access_token] [404] [5017:ms] [hats:1] [unauthenticated@_]
[INFO ] [01/12/2021 09:32:01] [api] [77.103.220.124] [POST:steveashby.hubofallthings.net:/control/v2/auth/passwordReset] [200] [2:ms] [hats:1] [unauthenticated@_] 

```

It is possible the error is caused by the reuse of Akka actor names as described here: https://stackoverflow.com/questions/28197940/actor-name-is-not-unique-akka
The error needs to be investigated, underlying cause understood and mitigating actions proposed. The issue is affecting clients in live environment.


## Source
https://dswift.atlassian.net/browse/DAS-117

## Type
- [ ] Bug Fix
- [x] Feature Addition 
- [ ] Refactor
- [ ] HotFix

## Checklist
- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test