### PR TITLE
HOTFIX: restore HTTP logging

### DIFF
--- a/hat/conf/play.conf
+++ b/hat/conf/play.conf
@@ -8,7 +8,6 @@ play {
     secret.key = ${?APPLICATION_SECRET}
     errorHandler = "org.hatdex.hat.utils.ErrorHandler"
     forwarded.trustedProxies=["0.0.0.0/0", "::/0"]
-    filters = "org.hatdex.hat.filters.PrometheusFilters"
   }
 
   i18n.langs = ["en", "pt", "pl"]
@@ -90,6 +89,7 @@ play {
     enabled += "play.filters.gzip.GzipFilter"
     enabled += "org.hatdex.hat.utils.LoggingFilter"
     enabled += "org.hatdex.hat.utils.TLSFilter"
+    // enabled += "org.hatdex.hat.filters.PrometheusFilters"
   }
 
   cache.bindCaches = ["session-cache", "user-cache"]


### PR DESCRIPTION
## Description

Recent update to the main codebase has accidentally disabled all of the filter-based HTTP logging. Hotfix aims to restore logging functionality by removing filter configuration override.

## Why

Recently a new configuration line has been added to `play.conf` file: `filters = "org.hatdex.hat.filters.PrometheusFilters"`. However, Play documentation states:

```Play now comes with a default set of enabled filters, defined through configuration. If the property play.http.filters is null, then the default is now play.api.http.EnabledFilters, which loads up the filters defined by fully qualified class name in the play.filters.enabled configuration property.```

As a result, the newly added config line has implicitly disabled the rest of active Play filters.

## AC

Restore filter-based HTTP logging in the HAT

## Type

- [x] Bug Fix
- [ ] Feature Addition
- [ ] Refactor
- [ ] HotFix

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
