### PR TITLE
DAS-440 #comment Change the route for Prometheus.

### DIFF
--- a/hat/conf/routes
+++ b/hat/conf/routes
@@ -27,6 +27,9 @@ POST        /control/v2/auth/claim                               org.hatdex.hat.
 POST        /control/v2/auth/request-verification                org.hatdex.hat.api.controllers.Authentication.handleVerificationRequest(lang: Option[String])
 POST        /control/v2/auth/claim/complete/:verificationToken   org.hatdex.hat.api.controllers.Authentication.handleVerification(verificationToken: String)
 
+# Metrics
+GET         /metrics                                             com.github.stijndehaes.playprometheusfilters.controllers.PrometheusController.getMetrics
+
 ->          /api/v2                                              v20.Routes
 ->          /api/v2.0                                            v20.Routes
 ->          /api/v2.6                                            v26.Routes

--- a/hat/conf/v26.routes
+++ b/hat/conf/v26.routes
@@ -83,6 +83,3 @@ POST          /contract-data/read/$namespace<[0-9a-z-]+>/$endpoint<[0-9a-z-/]+> 
 POST          /contract-data/create/$namespace<[0-9a-z-]+>/$endpoint<[0-9a-z-/]+>            org.hatdex.hat.api.controllers.ContractData.createContractData(namespace, endpoint, skipErrors: Option[Boolean])
 PUT           /contract-data/update/$namespace<[0-9a-z-]+>                                   org.hatdex.hat.api.controllers.ContractData.updateContractData(namespace)
 
-# Metrics
-# Hide for now
-GET           /metrics                                                                       com.github.stijndehaes.playprometheusfilters.controllers.PrometheusController.getMetrics


### PR DESCRIPTION
@pperzyna added as informational.

PR:
## Description
Prometheus has an excepted standard location for the metrics endpoint.  When I added support in the previous PR I put it behind `/api/v2.6/metrics` rather than `/metrics` so I fixed it.

## AC
As an Operator, it would be nice if the HAT exposed the prometheus endpoint on the expected route.
From `/api/v2.6/metrics` to `/metrics`

## Source
https://dswift.atlassian.net/browse/DAS-440

## Type
- [ ] Bug Fix
- [ ] Feature Addition 
- [x] Refactor
- [ ] HotFix

## Checklist
- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


