### PR TITLE
DAS-544 override .toString on three model objects to address a PII issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ project/metals.sbt
 .scalafix-common.conf
 .vscode
 /\.bsp
+project/project

--- a/hat/app/org/hatdex/hat/phata/models/HatClaims.scala
+++ b/hat/app/org/hatdex/hat/phata/models/HatClaims.scala
@@ -31,7 +31,7 @@ case class ApiVerificationRequest(
     email: String,
     redirectUri: String) {
   override def toString() =
-    s"applicationId: ${applicationId}, email:REDACTED, redirectUri: ${redirectUri}"
+    s"ApiVerificationRequest(applicationId: $applicationId, email:REDACTED, redirectUri: $redirectUri)"
 }
 
 object ApiVerificationRequest {
@@ -47,7 +47,7 @@ case class ApiVerificationCompletionRequest(
     hatCluster: String,
     password: String) {
   override def toString() =
-    s"email:REDACTED, termsAgreed:${termsAgreed}, optins:${optins}, hatName:${hatName}, hatCluster:${hatCluster}, password:REDACTED"
+    s"ApiVerificationCompletionRequest(email:REDACTED, termsAgreed:$termsAgreed, optins:$optins, hatName:$hatName, hatCluster:$hatCluster, password:REDACTED)"
 }
 
 case class HattersClaimPayload(
@@ -59,7 +59,7 @@ case class HattersClaimPayload(
     hatName: String,
     hatCluster: String) {
   override def toString() =
-    s"email:REDACTED, termsAgreed:${termsAgreed}, sandbox:${sandbox}, platform:${platform}, newsletterOptin:${newsletterOptin}, hatName:${hatName}, hatCluster:${hatCluster}"
+    s"HattersClaimPayload(email:REDACTED, termsAgreed:${termsAgreed}, sandbox:$sandbox, platform:$platform, newsletterOptin:$newsletterOptin, hatName:$hatName, hatCluster:$hatCluster)"
 
 }
 

--- a/hat/app/org/hatdex/hat/phata/models/HatClaims.scala
+++ b/hat/app/org/hatdex/hat/phata/models/HatClaims.scala
@@ -29,7 +29,10 @@ import play.api.libs.json.{ Json, OFormat, Reads, Writes }
 case class ApiVerificationRequest(
     applicationId: String,
     email: String,
-    redirectUri: String)
+    redirectUri: String) {
+  override def toString() =
+    s"applicationId: ${applicationId}, email:REDACTED, redirectUri: ${redirectUri}"
+}
 
 object ApiVerificationRequest {
   implicit val claimHatRequestApiFormat: OFormat[ApiVerificationRequest] =
@@ -42,7 +45,10 @@ case class ApiVerificationCompletionRequest(
     optins: Array[String],
     hatName: String,
     hatCluster: String,
-    password: String)
+    password: String) {
+  override def toString() =
+    s"email:REDACTED, termsAgreed:${termsAgreed}, optins:${optins}, hatName:${hatName}, hatCluster:${hatCluster}, password:REDACTED"
+}
 
 case class HattersClaimPayload(
     email: String,
@@ -51,7 +57,11 @@ case class HattersClaimPayload(
     platform: String,
     newsletterOptin: Option[Boolean],
     hatName: String,
-    hatCluster: String)
+    hatCluster: String) {
+  override def toString() =
+    s"email:REDACTED, termsAgreed:${termsAgreed}, sandbox:${sandbox}, platform:${platform}, newsletterOptin:${newsletterOptin}, hatName:${hatName}, hatCluster:${hatCluster}"
+
+}
 
 object ApiVerificationCompletionRequest {
   implicit val hatClaimRequestReads: Reads[ApiVerificationCompletionRequest] =

--- a/hat/test/org/hatdex/hat/utils/MiscTests.scala
+++ b/hat/test/org/hatdex/hat/utils/MiscTests.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 HAT Data Exchange Ltd
+ * SPDX-License-Identifier: AGPL-3.0
+ *
+ * This file is part of the Hub of All Things project (HAT).
+ *
+ * HAT is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, version 3 of
+ * the License.
+ *
+ * HAT is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.hatdex.hat.utils
+
+import io.dataswift.test.common.BaseSpec
+import play.api.Logger
+import org.hatdex.hat.phata.models.{ ApiVerificationCompletionRequest, ApiVerificationRequest, HattersClaimPayload }
+
+class HatClaimRedactionTests extends BaseSpec {
+
+  val logger: Logger                                 = Logger(this.getClass)
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  "HatClaim model objects" should "redact email and password when .toString is called" in {
+    val apiVerificationRequest =
+      new ApiVerificationRequest("AppId", "test@dataswift.io", "https://localhost:3000")
+
+    val apiVerificationCompletionRequest =
+      new ApiVerificationCompletionRequest("test@dataswift.io",
+                                           termsAgreed = false,
+                                           optins = Array.empty,
+                                           "hatName",
+                                           "hatCluster",
+                                           "password"
+      )
+
+    val hattersClaimPayload =
+      new HattersClaimPayload("test@dataswift.io",
+                              termsAgreed = false,
+                              sandbox = false,
+                              "platform",
+                              newsletterOptin = None,
+                              "hatName",
+                              "hatCluster"
+      )
+
+    // logger call invoke toString on case classes, etc.
+    apiVerificationRequest.toString() must include("email:REDACTED")
+    apiVerificationCompletionRequest.toString() must include("email:REDACTED")
+    apiVerificationCompletionRequest.toString() must include("password:REDACTED")
+    hattersClaimPayload.toString() must include("email:REDACTED")
+  }
+}


### PR DESCRIPTION
## Description
I overrode .toString() on three model objects to redact the PII (email and password).  This is a specific fix, not a general solution.  

## Source
https://dswift.atlassian.net/browse/DAS-544

## Type
- [x] Bug Fix
- [ ] Feature Addition 
- [ ] Refactor
- [ ] HotFix

## Checklist
- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test


