### PR TITLE
DAS-571 fix permission issue when deleting a contracted PDA file

### DIFF
--- a/hat/app/org/hatdex/hat/api/controllers/ContractFiles.scala
+++ b/hat/app/org/hatdex/hat/api/controllers/ContractFiles.scala
@@ -106,7 +106,8 @@ class ContractFiles @Inject() (
       (_, user, hatServer, maybeAuthenticator) =>
         val result =
           for {
-            file <- fileUploadService.getFile(fileId, user, None)(hatServer, maybeAuthenticator)
+            file <-
+              fileUploadService.getFile(fileId, user, None, cleanPermissions = false)(hatServer, maybeAuthenticator)
             accessAllowed <- Future(fileUploadService.fileAccessAllowed(user, file, None)(maybeAuthenticator))
             if accessAllowed
             _ = accessAllowed // to work around incorrect compiler warning

--- a/hat/app/org/hatdex/hat/api/service/FileUploadService.scala
+++ b/hat/app/org/hatdex/hat/api/service/FileUploadService.scala
@@ -33,7 +33,8 @@ trait FileUploadService {
   def getFile(
       fileId: String,
       user: HatUser,
-      maybeApplication: Option[HatApplication]
+      maybeApplication: Option[HatApplication],
+      cleanPermissions: Boolean = true
     )(implicit hatServer: HatServer,
       maybeAuthenticator: Option[HatApiAuthEnvironment#A]): Future[ApiHatFile]
 


### PR DESCRIPTION
## Description
while writing the documentation for file upload support in contracted PDAs, I found an issue with the deletion (it was forbidden when it should have been allowed).

## Type
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Refactor
- [ ] HotFix

## Checklist
- [x] tested on dev
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
