### PR TITLE
Add a config variable to set the idle timeout.

### DIFF
--- a/hat/conf/application.conf
+++ b/hat/conf/application.conf
@@ -75,6 +75,7 @@ silhouette {
   authenticator.fieldName = "X-Auth-Token"
   authenticator.issuerClaim = "example.com"
   authenticator.authenticatorIdleTimeout = 3 days
+  authenticator.authenticatorIdleTimeout = ${?AUTHENTICATOR_IDLE_TIMEOUT}
   authenticator.authenticatorExpiry = 30 days
 }
 


### PR DESCRIPTION
## Description
Add a new deployment config `${?AUTHENTICATOR_IDLE_TIMEOUT}` to allow the timeout to be set on deploy.

This is set by default to 3 days (as it was historically).