### PR TITLE
Tau support data filter

### DIFF
--- a/hat/app/org/hatdex/hat/api/controllers/RichData.scala
+++ b/hat/app/org/hatdex/hat/api/controllers/RichData.scala
@@ -92,11 +92,16 @@ class RichData @Inject() (
       val knownKeys = List("ordering", "orderBy", "skip", "take")
       val k: List[String] = request.queryString.keys.toList filterNot knownKeys.contains
             
-      // verify filter, this is dangerous
-      val filter = RichDataFilter(k.head, request.queryString.get(k.head).get.toList)
+      val dataFilter = if (k.length == 0) {
+        None
+      }
+      else {
+        Some(RichDataFilter(k.head, request.queryString.get(k.head).get.toList))
+      }
+      
       
       // anything that is not in the list above and be assumed to the attribute with the match being the predicate
-      makeData(namespace, endpoint, orderBy, ordering, skip, take, Some(filter))
+      makeData(namespace, endpoint, orderBy, ordering, skip, take, dataFilter)
     }
 
   def saveEndpointData(

--- a/hat/app/org/hatdex/hat/api/controllers/RichData.scala
+++ b/hat/app/org/hatdex/hat/api/controllers/RichData.scala
@@ -89,17 +89,10 @@ class RichData @Inject() (
           NamespaceRead(namespace)
         )
     ).async { implicit request =>
-      println(request.queryString)
       val knownKeys = List("ordering", "orderBy", "skip", "take")
       val k: List[String] = request.queryString.keys.toList filterNot knownKeys.contains
-      
-      // attribute name
-      println(k)
-      
-      // attribute value
-      println(request.queryString.get(k.head))
-      
-      // verify filter
+            
+      // verify filter, this is dangerous
       val filter = RichDataFilter(k.head, request.queryString.get(k.head).get.toList)
       
       // anything that is not in the list above and be assumed to the attribute with the match being the predicate
@@ -651,15 +644,15 @@ class RichData @Inject() (
 
   // {"object": {"id": 3, "date": "2022-12-03T17:32:51.482Z", "value": true, "nested": "no problem", "random": "238"}, "something": "Normal JSON"} 
   private def filterJson(data: Future[Seq[EndpointData]], filter: RichDataFilter): Future[Seq[EndpointData]] = {
-    println(s">> ${filter}")
+    // println(s">> ${filter}")
     data.map(d => {
       d.filter(a => {
-        println(a.data)
-        println(s">> attribute: ${filter.attribute}")
-        println(s">> value:     ${filter.value.head}")
-        println(s">> json extr: ${(a.data \\ filter.attribute).head}")
-        println(s">> json test: ${(a.data \\ filter.attribute).head.toString == filter.value.head}")
-        println((a.data \\ filter.attribute).map(_.as[String]))
+        // println(a.data)
+        // println(s">> attribute: ${filter.attribute}")
+        // println(s">> value:     ${filter.value.head}")
+        // println(s">> json extr: ${(a.data \\ filter.attribute).head}")
+        // println(s">> json test: ${(a.data \\ filter.attribute).head.toString == filter.value.head}")
+        // println((a.data \\ filter.attribute).map(_.as[String]))
         (a.data \\ filter.attribute).map(_.as[String]).contains(filter.value.head)
       })
     })

--- a/hat/app/org/hatdex/hat/api/controllers/RichData.scala
+++ b/hat/app/org/hatdex/hat/api/controllers/RichData.scala
@@ -630,11 +630,11 @@ class RichData @Inject() (
 
     val filteredData = filter match {
       case Some(dataFilter) => {
-        println(s"!!!filtering: ${dataFilter}")
+        // println(s"!!!filtering: ${dataFilter}")
         filterJson(data, dataFilter)
       }
       case None => {
-        println("!!!not filtering")
+        // println("!!!not filtering")
         data
       }
     }  

--- a/hat/app/org/hatdex/hat/api/controllers/RichData.scala
+++ b/hat/app/org/hatdex/hat/api/controllers/RichData.scala
@@ -63,6 +63,8 @@ class RichData @Inject() (
   private val logger             = loggingProvider.logger(this.getClass)
   private val defaultRecordLimit = 1000
 
+  case class RichDataFilter(attribute: String, value: List[String])
+
   /**
     * Returns Data Records for a given endpoint
     *
@@ -87,7 +89,21 @@ class RichData @Inject() (
           NamespaceRead(namespace)
         )
     ).async { implicit request =>
-      makeData(namespace, endpoint, orderBy, ordering, skip, take)
+      println(request.queryString)
+      val knownKeys = List("ordering", "orderBy", "skip", "take")
+      val k: List[String] = request.queryString.keys.toList filterNot knownKeys.contains
+      
+      // attribute name
+      println(k)
+      
+      // attribute value
+      println(request.queryString.get(k.head))
+      
+      // verify filter
+      val filter = RichDataFilter(k.head, request.queryString.get(k.head).get.toList)
+      
+      // anything that is not in the list above and be assumed to the attribute with the match being the predicate
+      makeData(namespace, endpoint, orderBy, ordering, skip, take, Some(filter))
     }
 
   def saveEndpointData(
@@ -605,19 +621,48 @@ class RichData @Inject() (
       orderBy: Option[String],
       ordering: Option[String],
       skip: Option[Int],
-      take: Option[Int]
+      take: Option[Int],
+      filter: Option[RichDataFilter]
     )(implicit db: HATPostgresProfile.api.Database): Future[Result] = {
     val dataEndpoint = s"$namespace/$endpoint"
     val query =
       Seq(EndpointQuery(dataEndpoint, None, None, None))
-    val data = dataService.propertyData(
+    val data: Future[Seq[EndpointData]] = dataService.propertyData(
       query,
       orderBy,
       ordering.contains("descending"),
       skip.getOrElse(0),
       take.orElse(Some(defaultRecordLimit))
     )
-    data.map(d => Ok(Json.toJson(d)))
+
+    val filteredData = filter match {
+      case Some(dataFilter) => {
+        println(s"!!!filtering: ${dataFilter}")
+        filterJson(data, dataFilter)
+      }
+      case None => {
+        println("!!!not filtering")
+        data
+      }
+    }  
+
+    filteredData.map(d => Ok(Json.toJson(d)))
+  }
+
+  // {"object": {"id": 3, "date": "2022-12-03T17:32:51.482Z", "value": true, "nested": "no problem", "random": "238"}, "something": "Normal JSON"} 
+  private def filterJson(data: Future[Seq[EndpointData]], filter: RichDataFilter): Future[Seq[EndpointData]] = {
+    println(s">> ${filter}")
+    data.map(d => {
+      d.filter(a => {
+        println(a.data)
+        println(s">> attribute: ${filter.attribute}")
+        println(s">> value:     ${filter.value.head}")
+        println(s">> json extr: ${(a.data \\ filter.attribute).head}")
+        println(s">> json test: ${(a.data \\ filter.attribute).head.toString == filter.value.head}")
+        println((a.data \\ filter.attribute).map(_.as[String]))
+        (a.data \\ filter.attribute).map(_.as[String]).contains(filter.value.head)
+      })
+    })
   }
 
   private object Errors {

--- a/hat/app/org/hatdex/hat/api/service/richData/RichDataService.scala
+++ b/hat/app/org/hatdex/hat/api/service/richData/RichDataService.scala
@@ -607,8 +607,7 @@ class RichDataService @Inject() (implicit ec: DalExecutionContext) extends Loggi
           val linked = linkedResults.map {
             case (linkedRecord, linkedQueryId) =>
               endpointDataWithMappers(linkedRecord, linkedQueryId, mappers)
-          }
-          
+          }          
           val endpointData =
             endpointDataWithMappers(record, queryId.toString, mappers)
           if (linked.nonEmpty)

--- a/hat/app/org/hatdex/hat/api/service/richData/RichDataService.scala
+++ b/hat/app/org/hatdex/hat/api/service/richData/RichDataService.scala
@@ -608,6 +608,7 @@ class RichDataService @Inject() (implicit ec: DalExecutionContext) extends Loggi
             case (linkedRecord, linkedQueryId) =>
               endpointDataWithMappers(linkedRecord, linkedQueryId, mappers)
           }
+          
           val endpointData =
             endpointDataWithMappers(record, queryId.toString, mappers)
           if (linked.nonEmpty)

--- a/hat/app/org/hatdex/hat/api/service/richData/RichDataService.scala
+++ b/hat/app/org/hatdex/hat/api/service/richData/RichDataService.scala
@@ -607,7 +607,7 @@ class RichDataService @Inject() (implicit ec: DalExecutionContext) extends Loggi
           val linked = linkedResults.map {
             case (linkedRecord, linkedQueryId) =>
               endpointDataWithMappers(linkedRecord, linkedQueryId, mappers)
-          }          
+          }
           val endpointData =
             endpointDataWithMappers(record, queryId.toString, mappers)
           if (linked.nonEmpty)


### PR DESCRIPTION
## Description

WIP: exact matching data filter

`{{schema}}{{hat}}{{path}}data/credentials/123?link=https%3A%2F%2Fexample.com%2Fd%2F1234`

Matches `link` with `https%3A%2F%2Fexample.com%2Fd%2F1234`
